### PR TITLE
New release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Chart 2.1.1 [ApiGW 1.6.1] - 2023-08-23
+### Helm changes
+- New applications versions:
+    apigw - 1.6.1
+    apigw-frontend - 1.0.3
+    redis - 1.0.1
+- Move `affinity` in main values.yaml file
+- Update deploymant for apigw application - add ports descriptions
+- Change `imagePullPolicy` for redis image to `IfNotPresent`
+- Switch to public redis image.
+
 ## Chart 2.1.0 [ApiGW 1.5.0] - 2023-07-05
 ### Helm changes
 - New applications versions:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: apigw_app
-version: 2.1.0
+version: 2.1.1
 description: The API Gateway application
 type: application
 keywords:
@@ -9,7 +9,7 @@ keywords:
 home: https://simulator.company
 dependencies:
   - name: apigw
-    version: 2.1.0
+    version: 2.1.1
   - name: apigw-frontend
     version: 2.0.2
   - name: apigw_ingress
@@ -23,4 +23,4 @@ maintainers:
 
 icon: "https://media-exp1.licdn.com/dms/image/C4E0BAQG_mUmw1UsyuA/company-logo_200_200/0/1525514455224?e=2147483647&v=beta&t=Bmmfd3W25bG64i0R7wY7ZeuMRw7-Y6Xsh94N4nvpWFk"
 
-appVersion: 1.5.0
+appVersion: 1.6.1

--- a/charts/apigw-frontend/templates/_helpers.tpl
+++ b/charts/apigw-frontend/templates/_helpers.tpl
@@ -10,12 +10,7 @@ release: {{ .Release.Name }}
 Image url
 */}}
 {{- define "apigw_frontend.imageUrl" -}}
-{{- $global := .Values.global -}}
-{{- $imageRegistry := coalesce $global.imageRegistry .Values.image.registry -}}
-{{- $repotype := $global.repotype }}
-{{- $imageRepo := .Values.image.repository -}}
-{{- $imageTag := $global.apigw.apigw_frontend.tag | default $.Chart.AppVersion -}}
-  {{- printf "%s/%s/%s:%s" .Values.global.imageRegistry $repotype $imageRepo $imageTag -}}
+{{ .Values.global.imageRegistry }}{{ if eq .Values.global.repotype "public" }}/public{{- else }}/{{ .Values.global.repotype }}{{- end }}/apigw-apigw-frontend:{{ .Values.global.apigw.apigw_frontend.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{/*

--- a/charts/apigw-frontend/templates/deployment.yaml
+++ b/charts/apigw-frontend/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.global.apigw.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/apigw/Chart.yaml
+++ b/charts/apigw/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: apigw
-version: 2.1.0
-appVersion: 1.5.0
+version: 2.1.1
+appVersion: 1.6.1
 description: The API Gateway service.

--- a/charts/apigw/templates/_helpers.tpl
+++ b/charts/apigw/templates/_helpers.tpl
@@ -11,7 +11,7 @@ tier: {{ .Values.appName| quote }}
 Image url
 */}}
 {{- define "apigw_app.imageUrl" -}}
-{{ .Values.global.imageRegistry }}{{ if eq .Values.global.repotype "public" }}/public/apigw{{- else }}/{{ .Values.global.repotype }}{{- end }}/apigw-apigw:{{ .Values.global.apigw.apigw_app.tag | default .Chart.AppVersion }}
+{{ .Values.global.imageRegistry }}{{ if eq .Values.global.repotype "public" }}/public{{- else }}/{{ .Values.global.repotype }}{{- end }}/apigw-apigw:{{ .Values.global.apigw.apigw_app.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{/*

--- a/charts/apigw/templates/deployment.yaml
+++ b/charts/apigw/templates/deployment.yaml
@@ -59,11 +59,21 @@ spec:
                   fieldPath: status.podIP
           {{- include "apigw_app.resources" . | indent 10 }}
           ports:
-            - containerPort: {{ $cfg.callback_server.listen_port }}
-            - containerPort: {{ $cfg.api_server.listen_port }}
-            - containerPort: {{ $cfg.proxy_server.listen_port }}
-            - containerPort: {{ $cfg.health_server.listen_port }}
-            - containerPort: {{ $cfg.sync_api_server.listen_port }}
+            - name: callback
+              containerPort: {{ $cfg.callback_server.listen_port }}
+              protocol: TCP
+            - name: apiserver
+              containerPort: {{ $cfg.api_server.listen_port }}
+              protocol: TCP
+            - name: proxyserver
+              containerPort: {{ $cfg.proxy_server.listen_port }}
+              protocol: TCP
+            - name: healthserver
+              containerPort: {{ $cfg.health_server.listen_port }}
+              protocol: TCP
+            - name: syncapiserver
+              containerPort: {{ $cfg.sync_api_server.listen_port }}
+              protocol: TCP
             {{- if .Values.global.serviceMonitor }}
             {{- if .Values.global.serviceMonitor.enabled }}
             - name: metrics
@@ -117,7 +127,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             successThreshold: 1
-            failureThreshold: 3  
+            failureThreshold: 3
         {{- if $d.debug_container }}
         - name: 'debug'
           image: 'docker-hub.middleware.biz/hub.docker.com/library/alpine:3.18'
@@ -137,3 +147,7 @@ spec:
             name: {{ .Release.Name }}-apigw-config
         - name: gops
           emptyDir: {}
+      {{- with .Values.global.apigw.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/apigw_ingress/templates/ingress-private.yaml
+++ b/charts/apigw_ingress/templates/ingress-private.yaml
@@ -10,6 +10,9 @@ metadata:
   name: {{ .Values.appName }}-ingress
   annotations: {{ toYaml .Values.global.ingress.annotations | nindent 4 }}
 spec:
+  {{- if and .Values.global.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.global.ingress.className }}
+  {{- end }}
   rules:
     - host: {{ include "apigw.hosts.api_server" . }}
       http:

--- a/charts/redis/templates/deployment-redis.yaml
+++ b/charts/redis/templates/deployment-redis.yaml
@@ -25,12 +25,8 @@ spec:
       {{- end }}
       containers:
       - name: master
-        {{- if .Values.global.arm64 }}
-        image: "{{ .Values.image.registry }}/public/arm64/redis:{{ .Values.image.tag }}"
-        {{- else }}
         image: "{{ .Values.image.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- end }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
           limits:
             cpu: 100m

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -2,5 +2,5 @@ appName: redis
 appPort: 6379
 image:
   registry: docker-hub.middleware.biz
-  repository: /public/redis
-  tag: 7.0.8
+  repository: /hub.docker.com/library/redis
+  tag: "7.0.8"


### PR DESCRIPTION
## Chart 2.1.1 [ApiGW 1.6.1] - 2023-08-23
### Helm changes
- New applications versions:
    apigw - 1.6.1
    apigw-frontend - 1.0.3
    redis - 1.0.1
- Move `affinity` in main values.yaml file
- Update deploymant for apigw application - add ports descriptions
- Change `imagePullPolicy` for redis image to `IfNotPresent`
- Switch to public redis image.