### PR TITLE
Update ApiGW Helm chart to version 2.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Chart 2.3.12 [ApiGW 1.11.0] - 2026.04.09
+### Helm changes
+- upgrade go1.26
+- upgrade all deps
+- use ubi-micro:9.7
+- added more debug logs
+
 ## Chart 2.3.11 [ApiGW 1.10.1] - 2025.12.05
 ### Helm changes
 - Applications versions:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: apigw_app
-version: 2.3.11
+version: 2.3.12
 description: The API Gateway application
 type: application
 keywords:
@@ -9,7 +9,7 @@ keywords:
 home: https://simulator.company
 dependencies:
   - name: apigw
-    version: 2.2.11
+    version: 2.2.12
   - name: apigw_ingress
     version: 0.1.1
   - name: redis-apigw
@@ -23,4 +23,4 @@ maintainers:
 
 icon: "https://media-exp1.licdn.com/dms/image/C4E0BAQG_mUmw1UsyuA/company-logo_200_200/0/1525514455224?e=2147483647&v=beta&t=Bmmfd3W25bG64i0R7wY7ZeuMRw7-Y6Xsh94N4nvpWFk"
 
-appVersion: 1.10.1
+appVersion: 1.11.0

--- a/charts/apigw/Chart.yaml
+++ b/charts/apigw/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: apigw
-version: 2.2.11
-appVersion: 1.10.1
+version: 2.2.12
+appVersion: 1.11.0
 description: The API Gateway service.
 
 # Added pprof support in version 2.2.11


### PR DESCRIPTION
- Updated root chart version from 2.3.11 to 2.3.12
- Updated appVersion from 1.10.1 to 1.11.0
- Updated apigw subchart version from 2.2.11 to 2.2.12 (appVersion 1.11.0)
- Updated CHANGELOG.md with new release entry